### PR TITLE
Custom AVI key frame interval

### DIFF
--- a/src/org.monte.media/org/monte/media/avi/AVIOutputStream.java
+++ b/src/org.monte.media/org/monte/media/avi/AVIOutputStream.java
@@ -118,7 +118,8 @@ public class AVIOutputStream extends AbstractAVIStream {
                 DataClassKey, byte[].class,
                 WidthKey, width, HeightKey, height, DepthKey, depth,
                 FixedFrameRateKey, true,
-                FrameRateKey, new Rational(rate, scale)));
+                FrameRateKey, new Rational(rate, scale),
+                KeyFrameIntervalKey, syncInterval));
         vt.scale = scale;
         vt.rate = rate;
         vt.syncInterval = syncInterval;

--- a/src/org.monte.media/org/monte/media/avi/AVIWriter.java
+++ b/src/org.monte.media/org/monte/media/avi/AVIWriter.java
@@ -132,7 +132,7 @@ public class AVIWriter extends AVIOutputStream implements MovieWriter {
         int tr = addVideoTrack(vf.get(EncodingKey),
                 vf.get(FrameRateKey).getDenominator(), vf.get(FrameRateKey).getNumerator(),
                 vf.get(WidthKey), vf.get(HeightKey), vf.get(DepthKey),
-                vf.get(FrameRateKey).floor(1).intValue());
+                vf.get(KeyFrameIntervalKey, vf.get(FrameRateKey).floor(1).intValue()));
         setCompressionQuality(tr, vf.get(QualityKey, 1.0f));
         return tr;
     }

--- a/src/org.monte.media/org/monte/media/avi/codec/video/RunLengthCodec.java
+++ b/src/org.monte.media/org/monte/media/avi/codec/video/RunLengthCodec.java
@@ -192,8 +192,10 @@ public class RunLengthCodec extends AbstractVideoCodec {
         }
         int offset = r.x + r.y * scanlineStride;
 
-        boolean isKeyframe = frameCounter== 0
-                || frameCounter % outputFormat.get(KeyFrameIntervalKey,outputFormat.get(FrameRateKey).intValue()) == 0;
+        Integer keyFrameInterval = outputFormat.get(KeyFrameIntervalKey, outputFormat.get(FrameRateKey).intValue());
+        boolean isKeyframe = frameCounter == 0
+                || keyFrameInterval == 0
+                || frameCounter % keyFrameInterval == 0;
         frameCounter++;
 
         try {


### PR DESCRIPTION
Currently, the key frame interval defaults to the framerate:
https://github.com/wrandelshofer/MonteMedia/blob/d628987f69a8a8c35d0a4221bc49b28534f8d467/src/org.monte.media/org/monte/media/avi/AVIWriter.java#L132-L135
This will disregard any user-defined [`KeyFrameIntervalKey`](https://github.com/wrandelshofer/MonteMedia/blob/d628987f69a8a8c35d0a4221bc49b28534f8d467/src/org.monte.media/org/monte/media/av/FormatKeys.java#L48-L53) values.

With my proposed changes the `KeyFrameIntervalKey` will take effect when specified by the user.

Additionally, a division by zero error when encoding with [RunLengthCodec](https://github.com/wrandelshofer/MonteMedia/blob/d628987f69a8a8c35d0a4221bc49b28534f8d467/src/org.monte.media/org/monte/media/avi/codec/video/RunLengthCodec.java#L195-L196) was fixed that arose as a result of setting the `KeyFrameIntervalKey` to 0.