### PR TITLE
Fix for array index calculation in method countPixels of Histogram class

### DIFF
--- a/org.monte.media/src/main/java/org.monte.media/org/monte/media/color/Histogram.java
+++ b/org.monte.media/src/main/java/org.monte.media/org/monte/media/color/Histogram.java
@@ -30,8 +30,8 @@ public class Histogram {
             row = raster.getPixels(0, y, w, 1, row);
             for (int x = 0, w3 = w * 3; x < w3; x += 3) {
                 ++rbin[row[x]];
-                ++gbin[row[x] + 1];
-                ++bbin[row[x] + 2];
+                ++gbin[row[x + 1]];
+                ++bbin[row[x + 2]];
             }
         }
     }


### PR DESCRIPTION
The index calculation for green and blue bins in the countPixels method of the Histogram class was corrected.
Previously, the code used row[x] + 1 and row[x] + 2 instead of row[x + 1] and row[x + 2], this caused an ArrayIndexOutOfBoundsException when processing pixels with maximum color values (255).

The proper indexing for RGB channels should prevent potential crashes.